### PR TITLE
Fix clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,14 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(piwcsprwmodel VERSION 1.0.1 LANGUAGES CXX)
+include(cmake/ClangTidy.cmake)
+include(cmake/Doxygen.cmake)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+project(piwcsprwmodel VERSION 1.0.1 LANGUAGES CXX)
+
 add_library(piwcsprwmodel)
-
-# Setup clang-tidy if available
-find_program(clang_tidy_EXECUTABLE NAMES clang-tidy-13 clang-tidy)
-if(clang_tidy_EXECUTABLE)
-    list(APPEND clang_tidy_command "${clang_tidy_EXECUTABLE}"
-        "--warnings-as-errors=*"
-        "--use-color")
-
-    set(CMAKE_CXX_CLANG_TIDY "${clang_tidy_command}")
-endif()
-
-# Setup doxygen if available
-find_package(Doxygen)
-if (DOXYGEN_FOUND)
-    set(DOXYGEN_JAVADOC_AUTOBRIEF YES)
-    set(DOXYGEN_INCLUDE_GRAPH NO)
-    set(DOXYGEN_INCLUDED_BY_GRAPH NO)
-    set(DOXYGEN_EXTRACT_STATIC YES)
-    set(DOXYGEN_IMAGE_PATH docs)
-    set(DOXYGEN_USE_MDFILE_AS_MAINPAGE README.md)
-    doxygen_add_docs(doxygen include README.md)
-endif()
 
 add_subdirectory(src)
 add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Install [GoogleTest](https://google.github.io/googletest/), reconfigure the proj
 
 Install [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) version 13 or later and reconfigure the project. All targets will now run clang-tidy checks on all compiled files.
 
+Use CMake option `SKIP_CLANG_TIDY` when configuring to disable automatic linting:
+```bash
+cmake -B build -DSKIP_CLANG_TIDY=ON ...
+```
+
 ### Formatting
 
 This project uses [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 13 or later for formatting. Many IDEs support `.clang-format` formatting specification out of the box.

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,0 +1,24 @@
+# Setup clang-tidy if available
+
+option(SKIP_CLANG_TIDY "Disable clang-tidy checks at compile time")
+
+if(SKIP_CLANG_TIDY)
+    message(STATUS "Skipping clang-tidy: disabled via option SKIP_CLANG_TIDY")
+    return()
+endif()
+
+if(NOT clang_tidy_EXECUTABLE)
+    find_program(clang_tidy_EXECUTABLE NAMES clang-tidy)
+endif()
+
+if(clang_tidy_EXECUTABLE)
+    message(STATUS "Found clang-tidy: ${clang_tidy_EXECUTABLE}")
+
+    list(APPEND clang_tidy_command "${clang_tidy_EXECUTABLE}"
+        "--warnings-as-errors=*"
+        "--use-color")
+
+    set(CMAKE_CXX_CLANG_TIDY "${clang_tidy_command}")
+else()
+    message(STATUS "clang-tidy not found; continuing")
+endif()

--- a/cmake/Doxygen.cmake
+++ b/cmake/Doxygen.cmake
@@ -1,0 +1,12 @@
+# Setup Doxygen if available
+
+find_package(Doxygen)
+if (DOXYGEN_FOUND)
+    set(DOXYGEN_JAVADOC_AUTOBRIEF YES)
+    set(DOXYGEN_INCLUDE_GRAPH NO)
+    set(DOXYGEN_INCLUDED_BY_GRAPH NO)
+    set(DOXYGEN_EXTRACT_STATIC YES)
+    set(DOXYGEN_IMAGE_PATH docs)
+    set(DOXYGEN_USE_MDFILE_AS_MAINPAGE README.md)
+    doxygen_add_docs(doxygen include README.md)
+endif()


### PR DESCRIPTION
## Fix clang-tidy

Clang-tidy is not set up properly. From my testing, it is unable to detect problems in piwcsprwmodel headers.

The following code in `model.h` must fail to compile unless a `[[nodiscard]]` is added to the method:
```c++
class Model {
  public:
    const IdMap<Node> &nodes() const { return m_nodes; }
```

### Checklist

- [ ] Code compiles with no warnings using GCC
- [ ] Code compiles with no warnings using clang
- [ ] Code has no clang-tidy errors/warnings
- [ ] All tests are up to date
- [ ] All tests pass
- [ ] Code is formatted according to `.clang-format`
- [ ] Inline documentation is up to date
- [ ] Documentation in `include/piwcsprwmodel.h` is up to date
- [ ] Doxygen produces no warnings
